### PR TITLE
Enable quantity selection on product cards

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -170,6 +170,11 @@ body {
     color: #d63384;
 }
 
+/* Quantity controls on product card */
+.qty-control input {
+    max-width: 60px;
+}
+
 /* Animasi dan styling untuk filter */
 #product-controls {
     opacity: 0;


### PR DESCRIPTION
## Summary
- allow quantity selection on each product card and remove detail button
- display product details when clicking the card (except on cart controls)
- support adding multiple items at once from the card
- small styling tweak for quantity controls

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686938b2e3508322b3b4f2390a685692